### PR TITLE
Return device paths (via stdout)

### DIFF
--- a/clean_arena.py
+++ b/clean_arena.py
@@ -5,7 +5,7 @@ import shutil
 
 def clean_arena():
     root = os.path.dirname(os.path.realpath(__file__))
-    shutil.rmtree(os.path.join(root, 'arena'))
+    shutil.rmtree(os.path.join(root, 'arena'), ignore_errors=True)
 
 if __name__ == '__main__':
     clean_arena()

--- a/populate_arena.py
+++ b/populate_arena.py
@@ -26,7 +26,7 @@ def populate_arena(devices):
 
         shutil.copytree(src, dst)
         
-        print("\t" + dst)
+        print("\t{0}|{1}".format(prm[0], dst))
 
         if len(prm) > 1:
             with open(os.path.join(dst, 'address'), 'w') as address:

--- a/populate_arena.py
+++ b/populate_arena.py
@@ -25,6 +25,8 @@ def populate_arena(devices):
         dst = os.path.join(root, 'arena', class_path[dev].format(prm[0]))
 
         shutil.copytree(src, dst)
+        
+        print("\t" + dst)
 
         if len(prm) > 1:
             with open(os.path.join(dst, 'address'), 'w') as address:


### PR DESCRIPTION
This makes the populate script print the paths that it created to stdout, each on its own line, separated by newlines. Each path is preceded on its line by a tab (`\t`) character, because tabs are not valid characters in paths, and errors don't start with tabs either; if the line starts with a tab, we know it is a path.

Question: should it print the device index along with the path, so that the caller doesn't have to keep track of the order in which they sent in the devices if there are multiple?

_also fixed error mentioned in #4._
