### PR TITLE
Print address as well as index and path in populate script

### DIFF
--- a/populate_arena.py
+++ b/populate_arena.py
@@ -26,7 +26,7 @@ def populate_arena(devices):
 
         shutil.copytree(src, dst)
 
-        print("\t{0}|{1}|{2}".format(prm[0], prm[1], dst))
+        print("\t{0}\t{1}\t{2}".format(prm[0], prm[1], dst))
 
         if len(prm) > 1:
             with open(os.path.join(dst, 'address'), 'w') as address:

--- a/populate_arena.py
+++ b/populate_arena.py
@@ -26,7 +26,7 @@ def populate_arena(devices):
 
         shutil.copytree(src, dst)
 
-        print("\t{0}|{1}".format(prm[0], dst))
+        print("\t{0}|{1}|{2}".format(prm[0], prm[1], dst))
 
         if len(prm) > 1:
             with open(os.path.join(dst, 'address'), 'w') as address:


### PR DESCRIPTION
I realized that the index isn't always going to be a useful identifier for identifying the device; because we don't distinguish between sensors and motors, there could be a `sensor0` and a `motor0`. This PR makes the populate script return the address as well.
