### PR TITLE
Support micropython

### DIFF
--- a/clean_arena.py
+++ b/clean_arena.py
@@ -1,11 +1,14 @@
 #!/usr/bin/env python
 
-import os
+import os.path
 import shutil
 
 def clean_arena():
-    root = os.path.dirname(os.path.realpath(__file__))
-    shutil.rmtree(os.path.join(root, 'arena'), ignore_errors=True)
+    root = os.path.dirname(__file__)
+    try:
+        shutil.rmtree(os.path.join(root, 'arena'))
+    except OSError:
+        pass
 
 if __name__ == '__main__':
     clean_arena()

--- a/micropython_patch.py
+++ b/micropython_patch.py
@@ -1,0 +1,37 @@
+"""
+Patches for shutil to add copyfile and copytree methods if not implemented natively
+"""
+import os
+import shutil
+
+if not hasattr(shutil, "copyfile"):
+    def copyfile(src, dst):
+        with open(src, 'rb') as fsrc, open(dst, 'wb') as fdst:
+            shutil.copyfileobj(fsrc, fdst)
+
+    shutil.copyfile = copyfile
+
+if not hasattr(shutil, "copytree"):
+    def copytree(src, dst):
+        names = os.listdir(src)
+
+        os.makedirs(dst)
+        errors = []
+        for name in names:
+            srcname = os.path.join(src, name)
+            dstname = os.path.join(dst, name)
+            try:
+                if os.path.isdir(srcname):
+                    copytree(srcname, dstname)
+                else:
+                    copyfile(srcname, dstname)
+            except Error as err:
+                errors.extend(err.args[0])
+            except OSError as why:
+                errors.append((srcname, dstname, str(why)))
+        
+        if errors:
+            raise Error(errors)
+        return dst
+
+    shutil.copytree = copytree

--- a/populate_arena.py
+++ b/populate_arena.py
@@ -2,6 +2,7 @@
 
 import os
 import shutil
+import micropython_patch
 
 # Where to put each device in the arena
 class_path = {
@@ -18,7 +19,7 @@ def populate_arena(devices):
     addresses.
     """
 
-    root = os.path.dirname(os.path.realpath(__file__))
+    root = os.path.dirname(__file__)
     src = os.path.join(root, 'devices', 'board-info')
     dst = os.path.join(root, 'arena', 'board-info')
 


### PR DESCRIPTION
For https://github.com/ev3dev/ev3dev-lang-python/pull/514, I wanted to be able to run our ev3dev-lang-python unit tests in Micropython. Because we directly invoke the fake-sys module via importing it, it needs to support the Micropython interpreter too... so this is my take on that. None of it feels "right" because this isn't really what Micropython is designed to do.