### PR TITLE
micropython-shutil: patch rmtree

### DIFF
--- a/clean_arena.py
+++ b/clean_arena.py
@@ -2,6 +2,8 @@
 
 import os.path
 import shutil
+import micropython_patch
+
 
 def clean_arena():
     root = os.path.dirname(__file__)

--- a/micropython_patch.py
+++ b/micropython_patch.py
@@ -1,10 +1,13 @@
 """
-Patch for shutil to add copytree methods if not implemented natively
+Patch for micropython-shutil to implement some shutil methods correctly/natively
 """
 import os
 import shutil
+import sys
 
-if not hasattr(shutil, "copytree"):
+
+if sys.implementation.name == "micropython":
+
     def copytree(src, dst):
         # Shim for copytree on micropython. There's no API in the micropython
         # lib for chmod or equivalent, so we use the system cp util.
@@ -14,4 +17,13 @@ if not hasattr(shutil, "copytree"):
             raise Exception("Error code while executing cp: {0}".format(res))
         return dst
 
+    def rmtree(dirname):
+        # rmtree in micropython v1.9.4 breaks on directories so use
+        # an os call to "rm -rf" to remove the directory.
+        res = os.system("rm -rf {0}".format(dirname))
+
+        if res != 0:
+            raise Exception("Error code while executing 'rm -rf {0}': {1}".format(dirname, res))
+
     shutil.copytree = copytree
+    shutil.rmtree = rmtree

--- a/populate_arena.py
+++ b/populate_arena.py
@@ -23,6 +23,9 @@ def populate_arena(devices):
     src = os.path.join(root, 'devices', 'board-info')
     dst = os.path.join(root, 'arena', 'board-info')
 
+    if os.path.isdir(dst):
+        shutil.rmtree(dst)
+
     shutil.copytree(src, dst)
 
     for dev_type, index, address in devices:

--- a/populate_arena.py
+++ b/populate_arena.py
@@ -23,9 +23,6 @@ def populate_arena(devices):
     src = os.path.join(root, 'devices', 'board-info')
     dst = os.path.join(root, 'arena', 'board-info')
 
-    if os.path.isdir(dst):
-        shutil.rmtree(dst)
-
     shutil.copytree(src, dst)
 
     for dev_type, index, address in devices:


### PR DESCRIPTION
os.walk (which is used by shutil.rmtree) is broken in 1.9.4 and thinks that the directories are files so when we try to os.unlink them it barfs. In v1.10 os.walk correctly IDs them as directories.



